### PR TITLE
Automate release process

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -45,14 +45,7 @@ jobs:
             libgirepository1.0-dev \
             ninja-build \
             valac
-          pip install \
-            Jinja2 \
-            Pygments \
-            Sphinx \
-            breathe \
-            gi-docgen \
-            meson \
-            pydata_sphinx_theme
+          pip install -r requirements.txt
           case ${GITHUB_REF} in
             refs/tags/*)
               version=${GITHUB_REF#refs/tags/}
@@ -96,17 +89,15 @@ jobs:
           path: html/
       - uses: actions/checkout@v3
         if: |
-          github.event_name == 'push' &&
-            (startsWith(github.ref, 'refs/tags/') ||
-             github.ref == 'refs/heads/main')
+          startsWith(github.ref, 'refs/tags/') ||
+            github.ref == 'refs/heads/main'
         with:
           ref: gh-pages
           path: gh-pages
       - name: Deploy
         if: |
-          github.event_name == 'push' &&
-            (startsWith(github.ref, 'refs/tags/') ||
-             github.ref == 'refs/heads/main')
+          startsWith(github.ref, 'refs/tags/') ||
+            github.ref == 'refs/heads/main'
         run: |
           rm -rf gh-pages/${VERSION}
           cp -a build/doc/html/ gh-pages/${VERSION}

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -23,6 +23,47 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  source:
+    name: Source
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare
+        run: |
+          case ${GITHUB_REF} in
+            refs/tags/*)
+              version=${GITHUB_REF#refs/tags/}
+              ;;
+            *)
+              version=${GITHUB_SHA}
+              ;;
+          esac
+          echo "VERSION=${version}" >> ${GITHUB_ENV}
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          path: datafusion-c-${{ env.VERSION }}
+      - name: Archive
+        run: |
+          rm -rf datafusion-c-${VERSION}/.git
+          tar cvzf datafusion-c-${VERSION}.tar.gz datafusion-c-${VERSION}
+          zip -r datafusion-c-${VERSION}.zip datafusion-c-${VERSION}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: tar.gz
+          path: datafusion-c-${{ env.VERSION }}.tar.gz
+      - uses: actions/upload-artifact@v3
+        with:
+          name: zip
+          path: datafusion-c-${{ env.VERSION }}.zip
+      - uses: softprops/action-gh-release@v1
+        if: |
+          startsWith(github.ref, 'refs/tags/')
+        with:
+          body_path: datafusion-c-${{ env.VERSION }}/doc/source/news/${{ env.VERSION }}.md
+          files: |
+            datafusion-c-${{ env.VERSION }}.tar.gz
+            datafusion-c-${{ env.VERSION }}.zip
+
   build:
     name: Build
     runs-on: ubuntu-22.04
@@ -84,22 +125,22 @@ jobs:
           #   target: debian-bookworm-arm64
           #   test-docker-image: arm64v8/debian:bookworm
           - label: Ubuntu Focal amd64
-            id: debian-focal-amd64
+            id: ubuntu-focal-amd64
             task-namespace: apt
             target: ubuntu-focal
             test-docker-image: ubuntu:focal
           # - label: Ubuntu Focal arm64
-          #   id: debian-focal-arm64
+          #   id: ubuntu-focal-arm64
           #   task-namespace: apt
           #   target: ubuntu-focal-arm64
           #   test-docker-image: arm64v8/ubuntu:focal
           - label: Ubuntu Jammy amd64
-            id: debian-jammy-amd64
+            id: ubuntu-jammy-amd64
             task-namespace: apt
             target: ubuntu-jammy
             test-docker-image: ubuntu:jammy
           # - label: Ubuntu Jammy arm64
-          #   id: debian-jammy-arm64
+          #   id: ubuntu-jammy-arm64
           #   task-namespace: apt
           #   target: ubuntu-jammy-arm64
           #   test-docker-image: arm64v8/ubuntu:jammy
@@ -107,8 +148,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - name: Checkout Arrow
-        uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           sudo apt update
@@ -118,8 +157,7 @@ jobs:
             ruby
       - name: Update version
         if: |
-          !startsWith(github.ref, 'refs/tags/') &&
-          !startsWith(github.ref, 'refs/heads/maintenance/')
+          !startsWith(github.ref, 'refs/tags/')
         run: |
           cd package
           rake version:update RELEASE_DATE=$(date +%Y-%m-%d)
@@ -145,13 +183,16 @@ jobs:
           startsWith(github.ref, 'refs/tags/')
         run: |
           mkdir -p ${{ matrix.id }}
+          shopt -s globstar
           cp -a package/${{ matrix.task-namespace }}/repositories/**/*.* ${{ matrix.id }}/
           tar czf ${{ matrix.id }}.tar.gz ${{ matrix.id }}
+          echo "VERSION=${GITHUB_REF#refs/tags/}" >> ${GITHUB_ENV}
       - name: Upload to release
         uses: softprops/action-gh-release@v1
         if: |
           startsWith(github.ref, 'refs/tags/')
         with:
+          body_path: doc/source/news/${{ env.VERSION }}.md
           files: |
             ${{ matrix.id }}.tar.gz
       - name: Test
@@ -160,4 +201,5 @@ jobs:
             --rm \
             --volume ${PWD}:/host:ro \
             ${{ matrix.test-docker-image }} \
-            /host/package/${{ matrix.task-namespace }}/test.sh
+            /host/package/${{ matrix.task-namespace }}/test.sh \
+            local

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,15 @@
+# Copyright 2022 Sutou Kouhei <kou@clear-code.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+/vendor/

--- a/dev/release/prepare.sh
+++ b/dev/release/prepare.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+# Copyright 2022 Sutou Kouhei <kou@clear-code.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eux
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 version"
+  echo " e.g.: $0 11.0.0"
+  exit 1
+fi
+
+version=$1
+major_version=$(echo ${version} | grep -o -E '^[0-9]+')
+
+source_dir="$(dirname "$0")/../.."
+
+git fetch origin --tags
+
+branch="prepare-${version}"
+git branch -D ${branch} || :
+git checkout -b ${branch} origin/main
+
+pushd "${source_dir}"
+sed -i'.bak' \
+  -e "s/^version = \".*\"/version = \"${version}\"/" \
+  Cargo.toml
+rm Cargo.toml.bak
+git add Cargo.toml
+
+sed -i'.bak' \
+  -e "s/^version = \'.*\'/version = \"${version}\"/" \
+  meson.build
+rm meson.build.bak
+git add meson.build
+popd
+
+pushd "${source_dir}/package/debian/"
+sed -i'.bak' -E \
+  -e "s/libdatafusion[0-9]+/libdatafusion${major_version}/g" \
+  -e "s/libdatafusion-glib[0-9]+/libdatafusion-glib${major_version}/g" \
+  -e "s/gir1\.2-datafusion-[0-9]+/gir1.2-datafusion-${major_version}/g" \
+  control
+rm control.bak
+git add control
+git mv gir1.2-datafusion-*.install \
+       gir1.2-datafusion-${major_version}.0.install
+git mv libdatafusion-glib[[:alnum:]]*.install \
+       libdatafusion-glib${major_version}.install
+git mv libdatafusion[[:alnum:]]*.install \
+       libdatafusion${major_version}.install
+popd
+
+pushd "${source_dir}/doc/"
+latest_news_md=$(ls source/news/*.md | sort -n -r | head -n1)
+sed \
+  -e "s/^# .*\$/# ${version} - $(date +%Y-%m-%d)/" \
+  ${latest_news_md} > source/news/${version}.md
+git add source/news/${version}.md
+sed -i'.bak' \
+  -e "N; /^\.\. toctree::/ a \ \ \ news/${version}" \
+  source/news.rst
+rm source/news.rst.bak
+git add source/news.rst
+sed -i'.bak' \
+  -e "\,^  'source' / 'news\.rst', i \ \ 'source' / 'news' / '${version}.md'," \
+  meson.build
+rm meson.build.bak
+git add meson.build
+popd
+
+pushd "${source_dir}/package"
+rake version:update
+git add .
+popd

--- a/dev/release/tag.sh
+++ b/dev/release/tag.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# Copyright 2022 Sutou Kouhei <kou@clear-code.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eux
+
+source_dir="$(dirname "$0")/../.."
+
+version=$(grep "^version" "${source_dir}/Cargo.toml" | \
+            head -n1 | \
+            grep -o "[0-9.]*")
+git tag -a -m "Release ${version}!!!" ${version}
+git push origin ${version}

--- a/dev/release/verify-packages.sh
+++ b/dev/release/verify-packages.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# Copyright 2022 Sutou Kouhei <kou@clear-code.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eux
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 rc"
+  echo "       $0 staging-rc"
+  echo "       $0 release"
+  echo "       $0 staging-release"
+  echo " e.g.: $0 rc              # Verify RC packages"
+  echo " e.g.: $0 staging-rc      # Verify RC packages on staging"
+  echo " e.g.: $0 release         # Verify release packages"
+  echo " e.g.: $0 staging-release # Verify release packages on staging"
+  exit 1
+fi
+
+verify_type="$1"
+
+source_dir="$(dirname "$0")/../.."
+
+pushd "${source_dir}"
+for dir in package/{apt,yum}/*; do
+  if [ ! -d "${dir}" ]; then
+    continue
+  fi
+  base_name=${dir##*/}
+  distribution=
+  code_name=
+  case ${base_name} in
+    *-aarch64|*-arm64)
+      ;;
+    almalinux-*|debian-*|ubuntu-*)
+      distribution=${base_name%-*}
+      code_name=${base_name#*-}
+      ;;
+  esac
+  if [ "${distribution}" = "" -o "#{code_name}" = "" ]; then
+    continue
+  fi
+  package_type=$(basename "$(dirname "${dir}")")
+  docker run \
+         --rm \
+         --volume "$PWD:/host" \
+         -it \
+         ${distribution}:${code_name} \
+         /host/package/${package_type}/test.sh \
+         "${verify_type}"
+done
+popd

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -23,6 +23,8 @@ depend_files = files(
   'source' / 'index.rst',
   'source' / 'install.rst',
   'source' / 'introduction.rst',
+  'source' / 'news' / '10.0.0.md',
+  'source' / 'news.rst',
   'source' / 'raw-c-api.rst',
 )
 depend_files += [gi_docgen_toml]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -26,7 +26,12 @@ release = version
 
 extensions = [
     'breathe',
+    'myst_parser',
 ]
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.md': 'markdown',
+}
 
 breathe_default_project = 'datafusion-c'
 breathe_domain_by_extension = {'h' : 'c'}

--- a/doc/source/developer.rst
+++ b/doc/source/developer.rst
@@ -11,24 +11,9 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
 
-DataFusion C
-============
+Developer
+=========
 
 .. toctree::
-   :maxdepth: 2
-   :caption: Contents:
 
-   introduction
-   install
-   example/sql
-   raw-c-api
-   glib-api
-   developer
-   news
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+   developer/release

--- a/doc/source/developer/release.rst
+++ b/doc/source/developer/release.rst
@@ -1,0 +1,75 @@
+.. Copyright 2022 Sutou Kouhei <kou@clear-code.com>
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+
+Release
+=======
+
+This document describes how to release a new version.
+
+Prepare
+-------
+
+1. Run ``dev/release/prepare.sh`` to create a branch for a new version
+   and prepare the branch.
+2. Update ``doc/source/news/${VERSION}.md``.
+3. Commit changes.
+4. Push the commit.
+5. Open a pull request.
+
+Here are command lines for them:
+
+.. code-block:: console
+
+   $ dev/release/prepare.sh ${VERSION}
+   $ editor doc/source/news/${VERSION}.md
+   $ git add doc/source/news/${VERSION}.md
+   $ git commit
+   $ git push
+
+Create a pull request for the branch on
+https://github.com/datafusion-contrib/datafusion-c/pulls .
+
+Tag and upload
+--------------
+
+We can tag after we merge the prepare branch:
+
+.. code-block:: console
+
+   $ dev/release/tag.sh
+
+Our CI jobs create ``.deb`` / ``.rpm`` packages automatically when we
+tag a new version. It takes about 20min. We need to wait for finishing
+these jobs.
+
+We can download the built ``.deb`` / ``.rpm`` packages and upload to
+https://apache.jfrog.io/artifactory/arrow/ after these jobs are
+finished. Note that this must be done by an Apache Arrow PMC member
+who registers his/her GPG key to
+https://dist.apache.org/repos/dist/release/arrow/KEYS . Because
+APT/Yum repositories at https://apache.jfrog.io/artifactory/arrow/ are
+for Apache Arrow. We just reuse these APT/Yum repositories. So we must
+follow policy of https://apache.jfrog.io/artifactory/arrow/ .
+
+.. see-also::
+
+   `Release Management Guide for Apache Arrow <apache-arrow-release_>`__.
+
+.. code-block:: console
+
+   $ rake -C package apt:rc yum:rc
+   $ dev/package/verify-packages.sh rc
+   $ rake -C package apt:release yum:release
+   $ dev/package/verify-packages.sh release
+
+.. _apache-arrow-release: https://arrow.apache.org/docs/developers/release.html

--- a/doc/source/news.rst
+++ b/doc/source/news.rst
@@ -11,24 +11,9 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
 
-DataFusion C
-============
+News
+====
 
 .. toctree::
-   :maxdepth: 2
-   :caption: Contents:
 
-   introduction
-   install
-   example/sql
-   raw-c-api
-   glib-api
-   developer
-   news
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+   news/10.0.0

--- a/doc/source/news/10.0.0.md
+++ b/doc/source/news/10.0.0.md
@@ -1,0 +1,19 @@
+<!--
+  Copyright 2022 Sutou Kouhei <kou@clear-code.com>
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# 10.0.0 - 2022-08-22
+
+Initial release!!!

--- a/example/meson.build
+++ b/example/meson.build
@@ -38,10 +38,13 @@ if generate_vapi
              kwargs: vala_example_executable_kwargs)
 endif
 
-install_data('sql-glib.py',
-             'sql-glib.rb',
-             'sql-glib.vala',
-             'sql.c',
+install_data('sql.c',
              'sql.py',
              'sql.rb',
+             install_dir: data_dir / 'datafusion' / 'example')
+
+install_data('sql-glib.c',
+             'sql-glib.py',
+             'sql-glib.rb',
+             'sql-glib.vala',
              install_dir: data_dir / 'datafusion-glib' / 'example')

--- a/package/Rakefile
+++ b/package/Rakefile
@@ -19,7 +19,12 @@ require_relative "../vendor/apache-arrow/dev/tasks/linux-packages/package-task"
 class DataFusionPackageTask < PackageTask
   def initialize
     super("datafusion-c", detect_version, detect_release_time)
-    @archive_name = "datafusion-c-#{@version}.tar.gz"
+  end
+
+  def define
+    super
+    define_rc_tasks
+    define_release_tasks
   end
 
   private
@@ -59,27 +64,30 @@ class DataFusionPackageTask < PackageTask
   def apt_targets_default
     [
       "debian-bullseye",
-      "debian-bullseye-arm64",
+      # "debian-bullseye-arm64",
       "debian-bookworm",
-      "debian-bookworm-arm64",
+      # "debian-bookworm-arm64",
       "ubuntu-focal",
-      "ubuntu-focal-arm64",
+      # "ubuntu-focal-arm64",
       "ubuntu-jammy",
-      "ubuntu-jammy-arm64",
+      # "ubuntu-jammy-arm64",
     ]
   end
 
   def yum_targets_default
     [
       "almalinux-8",
-      "almalinux-8-aarch64",
+      # "almalinux-8-aarch64",
       "almalinux-9",
-      "almalinux-9-aarch64",
+      # "almalinux-9-aarch64",
     ]
   end
 
   def built_package_url(target_namespace, target)
-    url = "https://github.com/datafusion-contrib/datafusion-c/releases/download/#{@version}/"
+    github_repository =
+      ENV["GITHUB_REPOSITORY"] || "datafusion-contrib/datafusion-c"
+    url = "https://github.com/#{github_repository}"
+    url << "/releases/download/#{@version}/"
     case target_namespace
     when :apt
       if target.end_with?("-arm64")
@@ -97,8 +105,16 @@ class DataFusionPackageTask < PackageTask
     url
   end
 
+  def apache_arrow_dir
+    "#{__dir__}/../vendor/apache-arrow"
+  end
+
+  def package_dir_name
+    "#{@package}-#{@version}"
+  end
+
   def download_packages(target_namespace)
-    download_dir = "#{__dir__}/vendor/apache-arrow/packages/#{@version}"
+    download_dir = "#{apache_arrow_dir}/packages/#{package_dir_name}"
     mkdir_p(download_dir)
     __send__("#{target_namespace}_targets").each do |target|
       url = built_package_url(target_namespace, target)
@@ -109,15 +125,68 @@ class DataFusionPackageTask < PackageTask
     end
   end
 
-  def define_download_tasks
+  def upload_rc(target_namespace)
+    targets = __send__("#{target_namespace}_targets")
+    cd(apache_arrow_dir) do
+      env = {
+        "CROSSBOW_JOB_ID" => package_dir_name,
+        "DEB_PACKAGE_NAME" => @package,
+        "STAGING" => ENV["STAGING"] || "no",
+        "UPLOAD_DEFAULT" => "0",
+      }
+      targets.each do |target|
+        distribution = target.split("-")[0].upcase
+        env["UPLOAD_#{distribution}"] = "1"
+      end
+      sh(env,
+         "dev/release/05-binary-upload.sh",
+         @version,
+         "0")
+    end
+  end
+
+  def define_rc_tasks
     [:apt, :yum].each do |target_namespace|
       tasks = []
       namespace target_namespace do
-        desc "Download #{target_namespace} packages"
-        task :download do
+        desc "Upload RC #{target_namespace} packages"
+        task :rc do
           download_packages(target_namespace)
+          upload_rc(target_namespace)
         end
-        tasks << "#{target_namespace}:download"
+        tasks << "#{target_namespace}:release"
+      end
+      task target_namespace => tasks
+    end
+  end
+
+  def release(target_namespace)
+    targets = __send__("#{target_namespace}_targets")
+    cd(apache_arrow_dir) do
+      env = {
+        "STAGING" => ENV["STAGING"] || "no",
+        "DEPLOY_DEFAULT" => "0",
+      }
+      targets.each do |target|
+        distribution = target.split("-")[0].upcase
+        env["DEPLOY_#{distribution}"] = "1"
+      end
+      sh(env,
+         "dev/release/post-02-binary.sh",
+         @version,
+         "0")
+    end
+  end
+
+  def define_release_tasks
+    [:apt, :yum].each do |target_namespace|
+      tasks = []
+      namespace target_namespace do
+        desc "Release #{target_namespace} packages"
+        task :release do
+          release(target_namespace)
+        end
+        tasks << "#{target_namespace}:release"
       end
       task target_namespace => tasks
     end

--- a/package/debian/changelog
+++ b/package/debian/changelog
@@ -1,0 +1,5 @@
+datafusion-c (10.0.0-1) unstable; urgency=low
+
+  * New upstream release.
+
+ -- Sutou Kouhei <kou@clear-code.com>  Mon, 22 Aug 2022 08:45:33 -0000

--- a/package/yum/datafusion-c.spec.in
+++ b/package/yum/datafusion-c.spec.in
@@ -86,6 +86,20 @@ Libraries and header files for DataFusion C.
 %{_libdir}/libdatafusion.so
 %{_libdir}/pkgconfig/datafusion.pc
 
+%package -n datafusion-examples
+Summary:	Examples for DataFusion C
+License:	Apache-2.0
+Requires:	datafusion-devel = %{version}-%{release}
+
+%description -n datafusion-examples
+Examples for DataFusion C.
+
+%files -n datafusion-examples
+%defattr(-,root,root,-)
+%doc README.md
+%license LICENSE
+%{_datadir}/datafusion/example/
+
 %package -n datafusion-glib%{major_version}-libs
 Summary:	Runtime libraries for DataFusion GLib
 License:	Apache-2.0
@@ -123,7 +137,6 @@ Libraries and header files for DataFusion GLib.
 %{_libdir}/libdatafusion-glib.a
 %{_libdir}/libdatafusion-glib.so
 %{_libdir}/pkgconfig/datafusion-glib.pc
-%{_datadir}/datafusion-glib/example/
 %{_datadir}/gir-1.0/DataFusion-*.gir
 %{_datadir}/vala/vapi/datafusion-glib.*
 
@@ -140,4 +153,20 @@ Documentation for DataFusion GLib.
 %license LICENSE
 %{_datadir}/gtk-doc/html/datafusion-glib/
 
+%package -n datafusion-glib-examples
+Summary:	Examples for DataFusion GLib
+License:	Apache-2.0
+Requires:	datafusion-glib-devel = %{version}-%{release}
+
+%description -n datafusion-glib-examples
+Examples for DataFusion GLib.
+
+%files -n datafusion-glib-examples
+%defattr(-,root,root,-)
+%doc README.md
+%license LICENSE
+%{_datadir}/datafusion-glib/example/
+
 %changelog
+* Mon Aug 22 2022 Sutou Kouhei <kou@clear-code.com> - 10.0.0-1
+- New upstream release.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,21 @@
+# Copyright 2022 Sutou Kouhei <kou@clear-code.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+Jinja2
+Pygments
+Sphinx
+breathe
+gi-docgen
+meson
+myst_parser
+pydata_sphinx_theme


### PR DESCRIPTION
fix #8
fix #27

* Add some scripts to release
  * dev/release/prepare.sh: For a new release.
  * dev/release/tag.sh: For tagging.
  * See
    https://datafusion-contrib.github.io/datafusion-c/main/developer/release.html
    how to release a new version.

* Add support for GitHub Releases
  * Create a release page automatically when we tag a new version

* Add support for publishing .deb/.rpm to
  https://apache.jfrog.io/artifactory/arrow/
  * See also:
    https://lists.apache.org/thread/f47nmpmmydmr9613jty21sgbv83pr9tq