### PR TITLE
Add support for writing a data frame as Parquet format

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,6 +111,7 @@ jobs:
           sudo apt install -y -V \
             libarrow-glib-dev \
             libgirepository1.0-dev \
+            libparquet-glib-dev \
             ninja-build \
             valac
           pip install meson

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Sutou Kouhei <kou@clear-code.com>
+# Copyright 2022-2023 Sutou Kouhei <kou@clear-code.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ arrow = { version = "34", features = ["ffi", "prettyprint"] }
 arrow-data = "34"
 datafusion = "21"
 libc = "0.2"
+parquet = { version = "34", features = ["arrow", "async"] }
 tokio = "1"
 
 [package.metadata.capi.header]

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@
 
 source "https://rubygems.org/"
 
+gem "rake"
 gem "red-arrow"
 gem "red-parquet"
 gem "test-unit"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # -*- ruby -*-
 #
-# Copyright 2022 Sutou Kouhei <kou@clear-code.com>
+# Copyright 2022-2023 Sutou Kouhei <kou@clear-code.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,4 +17,5 @@
 source "https://rubygems.org/"
 
 gem "red-arrow"
+gem "red-parquet"
 gem "test-unit"

--- a/datafusion-glib/data-frame-raw.h
+++ b/datafusion-glib/data-frame-raw.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Sutou Kouhei <kou@clear-code.com>
+ * Copyright 2022-2023 Sutou Kouhei <kou@clear-code.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,5 +25,9 @@ G_BEGIN_DECLS
 GDF_AVAILABLE_IN_10_0
 GDFDataFrame *
 gdf_data_frame_new_raw(DFDataFrame *raw_data_frame);
+
+GDF_AVAILABLE_IN_21_0
+DFParquetWriterProperties *
+gdf_parquet_writer_properties_get_raw(GDFParquetWriterProperties *properties);
 
 G_END_DECLS

--- a/datafusion-glib/data-frame.h
+++ b/datafusion-glib/data-frame.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Sutou Kouhei <kou@clear-code.com>
+ * Copyright 2022-2023 Sutou Kouhei <kou@clear-code.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,27 @@
 
 G_BEGIN_DECLS
 
+#define GDF_TYPE_PARQUET_WRITER_PROPERTIES      \
+  (gdf_parquet_writer_properties_get_type())
+G_DECLARE_DERIVABLE_TYPE(GDFParquetWriterProperties,
+                         gdf_parquet_writer_properties,
+                         GDF,
+                         PARQUET_WRITER_PROPERTIES,
+                         GObject)
+struct _GDFParquetWriterPropertiesClass
+{
+  GObjectClass parent_class;
+};
+
+GDF_AVAILABLE_IN_21_0
+GDFParquetWriterProperties *
+gdf_parquet_writer_properties_new(void);
+GDF_AVAILABLE_IN_21_0
+void
+gdf_parquet_writer_properties_set_max_row_group_size(
+  GDFParquetWriterProperties *properties,
+  guint64 size);
+
 #define GDF_TYPE_DATA_FRAME (gdf_data_frame_get_type())
 G_DECLARE_DERIVABLE_TYPE(GDFDataFrame,
                          gdf_data_frame,
@@ -39,6 +60,12 @@ gdf_data_frame_show(GDFDataFrame *data_frame, GError **error);
 GDF_AVAILABLE_IN_10_0
 GArrowTable *
 gdf_data_frame_to_table(GDFDataFrame *data_frame, GError **error);
+GDF_AVAILABLE_IN_21_0
+gboolean
+gdf_data_frame_write_parquet(GDFDataFrame *data_frame,
+                             const gchar *path,
+                             GDFParquetWriterProperties *properties,
+                             GError **error);
 
 
 G_END_DECLS

--- a/package/apt/debian-bookworm/Dockerfile
+++ b/package/apt/debian-bookworm/Dockerfile
@@ -76,5 +76,5 @@ RUN \
     ) > /usr/bin/${exe##*/} && \
     chmod +x /usr/bin/${exe##*/}; \
   done && \
-  MAKEFLAGS="-j$(nproc)" gem install red-arrow && \
+  MAKEFLAGS="-j$(nproc)" gem install red-parquet && \
   apt clean

--- a/package/apt/debian-bullseye/Dockerfile
+++ b/package/apt/debian-bullseye/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2022 Sutou Kouhei <kou@clear-code.com>
+# Copyright 2022-2023 Sutou Kouhei <kou@clear-code.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -73,6 +73,6 @@ RUN \
   done && \
   pip3 install --upgrade meson && \
   ln -s /usr/local/bin/meson /usr/bin/ && \
-  MAKEFLAGS="-j$(nproc)" gem install red-arrow && \
+  MAKEFLAGS="-j$(nproc)" gem install red-parquet && \
   apt clean && \
   rm -rf /var/lib/apt/lists/*

--- a/package/apt/ubuntu-focal/Dockerfile
+++ b/package/apt/ubuntu-focal/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2022 Sutou Kouhei <kou@clear-code.com>
+# Copyright 2022-2023 Sutou Kouhei <kou@clear-code.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -71,6 +71,6 @@ RUN \
   done && \
   pip3 install --upgrade meson && \
   ln -s /usr/local/bin/meson /usr/bin/ && \
-  MAKEFLAGS="-j$(nproc)" gem install red-arrow && \
+  MAKEFLAGS="-j$(nproc)" gem install red-parquet && \
   apt clean && \
   rm -rf /var/lib/apt/lists/*

--- a/package/apt/ubuntu-jammy/Dockerfile
+++ b/package/apt/ubuntu-jammy/Dockerfile
@@ -70,6 +70,6 @@ RUN \
     ) > /usr/bin/${exe##*/} && \
     chmod +x /usr/bin/${exe##*/}; \
   done && \
-  MAKEFLAGS="-j$(nproc)" gem install red-arrow && \
+  MAKEFLAGS="-j$(nproc)" gem install red-parquet && \
   apt clean && \
   rm -rf /var/lib/apt/lists/*

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -415,7 +415,6 @@ pub extern "C" fn df_parquet_writer_properties_set_max_row_group_size(
     properties.max_row_group_size = Some(size);
 }
 
-
 fn block_on<F: Future>(future: F) -> F::Output {
     tokio::runtime::Runtime::new().unwrap().block_on(future)
 }

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -403,17 +403,18 @@ pub extern "C" fn df_parquet_writer_properties_new() -> Box<DFParquetWriterPrope
 
 #[no_mangle]
 pub extern "C" fn df_parquet_writer_properties_free(
-    _options: Option<Box<DFParquetWriterProperties>>,
+    _properties: Option<Box<DFParquetWriterProperties>>,
 ) {
 }
 
 #[no_mangle]
 pub extern "C" fn df_parquet_writer_properties_set_max_row_group_size(
-    options: &mut DFParquetWriterProperties,
+    properties: &mut DFParquetWriterProperties,
     size: usize,
 ) {
-    options.max_row_group_size = Some(size);
+    properties.max_row_group_size = Some(size);
 }
+
 
 fn block_on<F: Future>(future: F) -> F::Output {
     tokio::runtime::Runtime::new().unwrap().block_on(future)
@@ -470,7 +471,7 @@ pub extern "C" fn df_data_frame_show(
 pub extern "C" fn df_data_frame_write_parquet(
     data_frame: &mut DFDataFrame,
     path: *const libc::c_char,
-    writer_properties: Option<Box<DFParquetWriterProperties>>,
+    writer_properties: Option<&DFParquetWriterProperties>,
     error: *mut *mut DFError,
 ) -> bool {
     let maybe_success = || -> Option<bool> {

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,4 +1,4 @@
-# Copyright 2022 Sutou Kouhei <kou@clear-code.com>
+# Copyright 2022-2023 Sutou Kouhei <kou@clear-code.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 require "tempfile"
+require "tmpdir"
 
 require "test-unit"
 
 require "arrow"
+require "parquet"
 require "gi"
 
 DataFusion = GI.load("DataFusion")


### PR DESCRIPTION
fix #36

Note that write options are incomplete. Currently the max row group size is only available.