### PR TITLE
Fix lint failure

### DIFF
--- a/src/capi.rs
+++ b/src/capi.rs
@@ -648,7 +648,7 @@ pub extern "C" fn df_session_context_register_record_batches(
         for c_abi_record_batch in c_abi_record_batch_slice {
             let rs_ffi_record_batch = unsafe {
                 std::ptr::replace(
-                    (*c_abi_record_batch as *mut DFArrowArray) as *mut FFI_ArrowArray,
+                    *c_abi_record_batch as *mut FFI_ArrowArray,
                     FFI_ArrowArray::empty(),
                 )
             };


### PR DESCRIPTION
fix #58

    error: casting raw pointers to the same type and constness is unnecessary (`*mut capi::DFArrowArray` -> `*mut capi::DFArrowArray`)
       --> src/capi.rs:651:21
        |
    651 |                     (*c_abi_record_batch as *mut DFArrowArray) as *mut FFI_ArrowArray,
        |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `*c_abi_record_batch`
        |
        = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast
        = note: `-D clippy::unnecessary-cast` implied by `-D clippy::all`